### PR TITLE
S7 could not retrieve the 6th bit of a byte

### DIFF
--- a/src/com/sourceforge/snap7/moka7/S7.java
+++ b/src/com/sourceforge/snap7/moka7/S7.java
@@ -66,7 +66,7 @@ public class S7 {
         int Value = Buffer[Pos] & 0x0FF;
         byte[] Mask = {
             (byte)0x01,(byte)0x02,(byte)0x04,(byte)0x08,
-            (byte)0x10,(byte)0x10,(byte)0x40,(byte)0x80
+            (byte)0x10,(byte)0x20,(byte)0x40,(byte)0x80
         };   
         if (Bit<0) Bit=0;
         if (Bit>7) Bit=7;


### PR DESCRIPTION
A copy/paste error on Moka7 prevented anyone from reading the 6th bit of a byte